### PR TITLE
Downgrade Gradle to 8.11.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath 'com.android.tools.build:gradle:8.11.2'
     }
 }
 


### PR DESCRIPTION
Gradle version 8.13.0 isn't supported by f-droid yet
See https://github.com/MiepHD/cuscon/issues/77 (In the issue is suggested to use 8.11.1 but 8.11.2 works fine too)
As this project aims to work with F-Droid I'd suggest to downgrade to 8.11.2